### PR TITLE
Take existing query string into account.

### DIFF
--- a/src/more_ds/network/url.py
+++ b/src/more_ds/network/url.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from typing import Mapping
-from urllib.parse import urlencode
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 
 class URL(str):
@@ -69,8 +69,10 @@ class URL(str):
         Returns:
             a new URL object with the `query` appended as a query string.
         """
-        params = urlencode(query)
-        return URL(self + f"?{params}")
+        parts = urlparse(self)
+        params = {**parse_qs(parts.query), **query}
+        parts = parts._replace(query=urlencode(params, doseq=True))
+        return URL(urlunparse(parts))
 
     def __repr__(self) -> str:
         """Return printable presentation of URL."""

--- a/tests/network/test_url.py
+++ b/tests/network/test_url.py
@@ -12,6 +12,7 @@
 #  limitations under the License.
 #
 
+from urllib.parse import parse_qs, urlparse
 from more_ds.network.url import URL
 
 
@@ -39,4 +40,5 @@ def test_url() -> None:  # noqa: D103
 
     url = api_url / "ip" / "address" // {"version": 4}
     url = URL(str(url)) // {"extra": [2]}
-    assert "http://example.org/api/ip/address?version=4&extra=2" == url
+    parts = urlparse(url)
+    assert parse_qs(parts.query) == {"version": ["4"], "extra": ["2"]}

--- a/tests/network/test_url.py
+++ b/tests/network/test_url.py
@@ -36,3 +36,7 @@ def test_url() -> None:  # noqa: D103
     # query string properly url encoded?
     url = api_url // {"query": ' "%-.<>\\^_`{|}~'}
     assert "http://example.org/api?query=+%22%25-.%3C%3E%5C%5E_%60%7B%7C%7D~" == url
+
+    url = api_url / "ip" / "address" // {"version": 4}
+    url = URL(str(url)) // {"extra": [2]}
+    assert "http://example.org/api/ip/address?version=4&extra=2" == url


### PR DESCRIPTION
When appending a new query string using the __floor_div__ overload,
take into account that the existing url could already have a
query string attached.